### PR TITLE
[fix]M1 MacでDockerをbuildするとnokogiriのエラーが出てしまう点の修正

### DIFF
--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -98,6 +98,8 @@ GEM
     net-smtp (0.3.2)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.13.9-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.13.9-x86_64-linux)
       racc (~> 1.4)
     pg (1.4.4)
@@ -158,6 +160,7 @@ GEM
     zeitwerk (2.6.1)
 
 PLATFORMS
+  aarch64-linux-musl
   x86_64-linux-musl
 
 DEPENDENCIES

--- a/conf/api/Dockerfile
+++ b/conf/api/Dockerfile
@@ -23,6 +23,9 @@ RUN apk update && \
         curl-dev && \
     apk del build-packs
 
+RUN apk add --no-cache gcompat
+#nokogiriで詰まったので入れました。
+
 COPY api/Gemfile ${ROOT}
 COPY api/Gemfile.lock ${ROOT}
 


### PR DESCRIPTION
DockerファイルにRUN apk add --no-cache gcompatを記載しました。